### PR TITLE
Export rateLimiter

### DIFF
--- a/rate_limiter.go
+++ b/rate_limiter.go
@@ -5,8 +5,8 @@ import (
 	"time"
 )
 
-// A rateLimiter limits the rate at which an action can be performed.
-type rateLimiter struct {
+// A RateLimiter limits the rate at which an action can be performed.
+type RateLimiter struct {
 	limit               int
 	interval            time.Duration
 	waitMutex, tryMutex *sync.Mutex
@@ -15,8 +15,8 @@ type rateLimiter struct {
 }
 
 // New creates a new rate limiter for the limit and interval.
-func New(limit int, interval time.Duration) *rateLimiter {
-	return &rateLimiter{
+func New(limit int, interval time.Duration) *RateLimiter {
+	return &RateLimiter{
 		limit:     limit,
 		interval:  interval,
 		waitMutex: &sync.Mutex{},
@@ -26,7 +26,7 @@ func New(limit int, interval time.Duration) *rateLimiter {
 }
 
 // Wait will block if the rate limit has been reached.
-func (r *rateLimiter) Wait() {
+func (r *RateLimiter) Wait() {
 	r.waitMutex.Lock()
 	defer r.waitMutex.Unlock()
 	for {
@@ -40,7 +40,7 @@ func (r *rateLimiter) Wait() {
 
 // Try will return true if under the rate limit, or false if over and the
 // remaining time before the rate limit expires.
-func (r *rateLimiter) Try() (ok bool, remaining time.Duration) {
+func (r *RateLimiter) Try() (ok bool, remaining time.Duration) {
 	r.tryMutex.Lock()
 	defer r.tryMutex.Unlock()
 	if len(r.times) == r.limit {


### PR DESCRIPTION
First of all: great package! Thanks for creating this.

This PR allows `go doc` to display RateLimiter (and it's methods).
It's also conventional to export major types.
