### PR TITLE
Further polish under-the-hood and docstrings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,4 @@ Authors
 
 * [Michael Alexander](https://github.com/beefsack)
 * [Geert-Johan Riemer](https://github.com/GeertJohan)
+* [Matt T. Proud](https://github.com/matttproud)

--- a/rate.go
+++ b/rate.go
@@ -1,26 +1,36 @@
 package rate
 
 import (
+	"container/list"
 	"sync"
 	"time"
 )
 
-// A RateLimiter limits the rate at which an action can be performed.
+// A RateLimiter limits the rate at which an action can be performed.  It
+// applies neither smoothing (like one could achieve in a token bucket system)
+// nor does it offer any conception of warmup, wherein the rate of actions
+// granted are steadily increased until a steady throughput equilibrium is
+// reached.
 type RateLimiter struct {
+	limit    int
 	interval time.Duration
 	mtx      sync.Mutex
-	times    []time.Time
+	times    list.List
 }
 
 // New creates a new rate limiter for the limit and interval.
 func New(limit int, interval time.Duration) *RateLimiter {
-	return &RateLimiter{
+	lim := &RateLimiter{
+		limit:    limit,
 		interval: interval,
-		times:    make([]time.Time, 0, limit),
 	}
+	lim.times.Init()
+	return lim
 }
 
-// Wait will block if the rate limit has been reached.
+// Wait blocks if the rate limit has been reached.  Wait offers no guarantees
+// of fairness for multiple actors if the allowed rate has been temporarily
+// exhausted.
 func (r *RateLimiter) Wait() {
 	for {
 		ok, remaining := r.Try()
@@ -31,19 +41,21 @@ func (r *RateLimiter) Wait() {
 	}
 }
 
-// Try will return true if under the rate limit, or false if over and the
+// Try returns true if under the rate limit, or false if over and the
 // remaining time before the rate limit expires.
 func (r *RateLimiter) Try() (ok bool, remaining time.Duration) {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
 	now := time.Now()
-	if l := len(r.times); l == cap(r.times) {
-		if diff := now.Sub(r.times[0]); diff < r.interval {
-			return false, r.interval - diff
-		}
-		copy(r.times, r.times[1:])
-		r.times = r.times[:l-1]
+	if l := r.times.Len(); l < r.limit {
+		r.times.PushBack(now)
+		return true, 0
 	}
-	r.times = append(r.times, now)
+	frnt := r.times.Front()
+	if diff := now.Sub(frnt.Value.(time.Time)); diff < r.interval {
+		return false, r.interval - diff
+	}
+	frnt.Value = now
+	r.times.MoveToBack(frnt)
 	return true, 0
 }


### PR DESCRIPTION
The first change makes RateLimiter operate in constant time with
respect to the number of operations allowed per period.  Under the
current (and previous design as well), the amount of time required
per operation is primarily a function of the number of operations
allowed per unit of time (i.e., buffer/slice size).  Under the proposed
design, once RateLimiter is warmed up with requests, we can avoid
expensive O(n) copies by using a linked list and performing pointer
swapping instead.  The results of the benchmark are profound:

https://gist.github.com/matttproud/2d0ca7bbf2321cfd2b25

The second change is to enhance the docstrings and have them further
explain the contract that a user of the RateLimiter can expect: Bursty
refills, no smoothing, no warmup period, and no guarantees of fairness.
None of these points are necessarily a limitation; only certain uses
may have them.
